### PR TITLE
Change npm project name to "coffee-break-quiz-app"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-quiz-starter",
+  "name": "coffee-break-quiz-app",
   "version": "1.0.0",
   "scripts": {
     "prettier:write": "prettier --write .",


### PR DESCRIPTION
This pull request includes a single commit that changes the name of the npm project from "js-quiz-starter" to "coffee-break-quiz-app".

closes #1 